### PR TITLE
Fix incorrect name_key for fb:app_id

### DIFF
--- a/lib/meta_tags/renderer.rb
+++ b/lib/meta_tags/renderer.rb
@@ -30,6 +30,7 @@ module MetaTags
       render_links(tags)
 
       render_hash(tags, :og, name_key: :property)
+      render_hash(tags, :fb, name_key: :property)
       render_hashes(tags)
       render_custom(tags)
 


### PR DESCRIPTION
- Fixes #118 (https://github.com/kpumuk/meta-tags/issues/118)